### PR TITLE
Put styletron engine into global window object to prevent multiple in…

### DIFF
--- a/code/utils/StyletronEngine.ts
+++ b/code/utils/StyletronEngine.ts
@@ -1,3 +1,13 @@
-import {Client as Styletron} from 'styletron-engine-atomic';
+import { Client as Styletron } from 'styletron-engine-atomic';
 
-export const engine = new Styletron();
+declare global {
+  interface Window {
+    styletronEngine: Styletron;
+  }
+}
+
+if(!window.styletronEngine) {
+  window.styletronEngine = new Styletron();
+}
+
+export const engine = window.styletronEngine;


### PR DESCRIPTION
Store Styletron engine in the window to avoid multiple instances being instantiated during partial recompilation